### PR TITLE
Fixing incorrect link to column types from column options

### DIFF
--- a/backend-lists.md
+++ b/backend-lists.md
@@ -131,7 +131,7 @@ For each column can specify these options (where applicable):
 Option  | Description
 ------------- | -------------
 **label** | a name when displaying the list column to the user.
-**type** | defines how this column should be rendered (see [Column types](column-types) below).
+**type** | defines how this column should be rendered (see [Column types](#column-types) below).
 **options** | options used by a render type used (optional).
 **searchable** | include this field in the list search results. Default: no.
 **invisible** | specifies if this column is hidden by default. Default: no.


### PR DESCRIPTION
The link to column types in column options was missing the hash (#).
