### PR TITLE
Correct invalid namespace and regular expression

### DIFF
--- a/plugin-components.md
+++ b/plugin-components.md
@@ -29,7 +29,7 @@ The **component class file** defines the component functionality and [component 
 
     namespace Acme\Blog\Components;
 
-    class BlogPosts extends Cms\Classes\ComponentBase
+    class BlogPosts extends \Cms\Classes\ComponentBase
     {
         public function componentDetails()
         {
@@ -88,8 +88,8 @@ When you add a component to a page or layout you can configure it using properti
                  'description'       => 'The most amount of todo items allowed',
                  'default'           => 10,
                  'type'              => 'string',
-                 'validationPattern' => '^[a-zA-Z]*$',
-                 'validationMessage' => 'The Max Items property can contain only Latin symbols'
+                 'validationPattern' => '^[0-9]+$',
+                 'validationMessage' => 'The Max Items property can contain only numeric symbols'
             ]
         ];
     }


### PR DESCRIPTION
Correct invalid namespace and regular expression. Without backslash it throws:

![snimek obrazovky 2015-03-30 v 14 17 45](https://cloud.githubusercontent.com/assets/374917/6897294/f29b53aa-d6f2-11e4-822f-05273239e942.png)