### PR TITLE
Fix missing '/' in recordUrl example

### DIFF
--- a/backend-relations.md
+++ b/backend-relations.md
@@ -78,7 +78,7 @@ These configuration values can be specified only for the **view** options.
 Option  | Type | Description
 ------------- | ------------- | -------------
 **showCheckboxes** | List | displays checkboxes next to each record. Default: false.
-**recordUrl** | List | link each list record to another page. Eg: **users/update:id**. The `:id` part is replaced with the record identifier.
+**recordUrl** | List | link each list record to another page. Eg: **users/update/:id**. The `:id` part is replaced with the record identifier.
 **recordOnClick** | List | custom JavaScript code to execute when clicking on a record.
 **toolbarPartial** | Both | a reference to a controller partial file with the toolbar buttons. Eg: **_relation_toolbar.htm**. This option overrides the *toolbarButtons* option.
 **toolbarButtons** | Both | the set of buttons to display, can be an array or a pipe separated string. Available options are: add, create, update, delete, remove, link, unlink. Eg: **add\|remove**

--- a/backend-relations.md
+++ b/backend-relations.md
@@ -77,7 +77,7 @@ These configuration values can be specified only for the **view** options.
 
 Option  | Type | Description
 ------------- | ------------- | -------------
-**showCheckboxes** | List | displays checkboxes next to each record. Default: false.
+**showCheckboxes** | List | displays checkboxes next to each record.
 **recordUrl** | List | link each list record to another page. Eg: **users/update/:id**. The `:id` part is replaced with the record identifier.
 **recordOnClick** | List | custom JavaScript code to execute when clicking on a record.
 **toolbarPartial** | Both | a reference to a controller partial file with the toolbar buttons. Eg: **_relation_toolbar.htm**. This option overrides the *toolbarButtons* option.


### PR DESCRIPTION
Fixes a missing slash in the `recordUrl` example and removes the misleading default from `showCheckboxes`.