### PR TITLE
Add required  attribute to example import model

### DIFF
--- a/backend-import-export.md
+++ b/backend-import-export.md
@@ -154,6 +154,11 @@ For importing data you should create a dedicated model for this process which ex
 
     class SubscriberImport extends \Backend\Models\ImportModel
     {
+        /**
+         * @var array The rules to be applied to the data.
+         */
+        public $rules = [];
+
         public function importData($results, $sessionKey = null)
         {
             foreach ($results as $row => $data) {


### PR DESCRIPTION
ImportModel [uses the Validation trait](https://github.com/octobercms/october/blob/master/modules/backend/models/ImportModel.php#L14) which [requires a $rules property](https://github.com/octobercms/library/blob/master/src/Database/Traits/Validation.php#L12-L16) so I added it to the example import model docs.

Without this line, you get the error

> You must define a $rules property in My\Plugin\Models\MyImport to use the Validation trait.