### PR TITLE
Update services-validation.md

### DIFF
--- a/services-validation.md
+++ b/services-validation.md
@@ -556,8 +556,8 @@ Instead of using Closure callbacks to extend the Validator, you may also extend 
 
 Next, you need to register your custom Validator extension:
 
-    Validator::resolver(function($translator, $data, $rules, $messages) {
-        return new CustomValidator($translator, $data, $rules, $messages);
+    Validator::resolver(function($translator, $data, $rules, $messages, $customAttributes) {
+        return new CustomValidator($translator, $data, $rules, $messages, $customAttributes);
     });
 
 When creating a custom validation rule, you may sometimes need to define custom placeholder replacements for error messages. You may do so by creating a custom Validator as described above, and adding a `replaceXXX` function to the validator.


### PR DESCRIPTION
`$customAttributes` are needed for setting Validator custom attribute names. See Illuminate\Validation\Validator.php constructor:

```
public function __construct(TranslatorInterface $translator, array $data, array $rules, array $messages = array(), array $customAttributes = array())
{
	$this->translator = $translator;
	$this->customMessages = $messages;
	$this->data = $this->parseData($data);
	$this->rules = $this->explodeRules($rules);
	$this->customAttributes = $customAttributes;
}
```