### PR TITLE
Proof Reading of Markup Docs

### DIFF
--- a/markup-filter-default.md
+++ b/markup-filter-default.md
@@ -10,6 +10,6 @@ The `|default` filter returns the value passed as the first argument if the filt
 
     {{ ''|default('The variable is empty')  }}
 
-When using the default filter on an expression that uses variables in some method calls, be sure to use the default filter whenever a variable can be undefined:
+When using the `default` filter on an expression that uses variables in some method calls, be sure to use the `default` filter whenever a variable can be undefined:
 
     {{ variable.method(foo|default('bar'))|default('bar') }}

--- a/markup-filter-page.md
+++ b/markup-filter-page.md
@@ -23,7 +23,7 @@ When linking to a page that has URL parameters defined, the `|page` filter suppo
     ==
     [...]
 
-Given the above contents is found in a CMS page file **post.htm** you can link to this page using:
+Given the above content is found in a CMS page file **post.htm** you can link to this page using:
 
     <a href="{{ 'post'|page({ post_id: 10 }) }}">
         Blog post #10

--- a/markup-filter-raw.md
+++ b/markup-filter-raw.md
@@ -1,6 +1,6 @@
 # |raw
 
-Output variables in October are automatically escape, the `|raw` filter marks the value as being "safe" and will not be escaped if raw is the last filter applied.
+Output variables in October are automatically escaped, the `|raw` filter marks the value as being "safe" and will not be escaped if `raw` is the last filter applied.
 
     {# This variable won't be escaped #}
     {{ variable|raw }}

--- a/markup-filter-theme.md
+++ b/markup-filter-theme.md
@@ -40,7 +40,7 @@ Alias | Description
 `@framework` | AJAX framework extras, subsitute for `{% framework %}` tag. (JavaScript)
 `@framework.extras` | AJAX framework extras, subsitute for `{% framework extras %}` tag. (JavaScript, CSS)
 
-The same alias can be used for JavaScript or CSS, for example `@framework.extras`, at least one explicit reference with a file extension is needed in the array to determine which is used.
+The same alias can be used for JavaScript or CSS, for example `@framework.extras`. At least one explicit reference with a file extension is needed in the array to determine which is used.
 
 <a name="external-combiner-paths"></a>
 ### External combiner paths

--- a/markup-function-form.md
+++ b/markup-function-form.md
@@ -1,10 +1,10 @@
 # form()
 
-Functions prefixed with `form_` perform tasks that are useful when dealing with forms. The helper maps directly to the `Form` PHP class and its methods.
+Functions prefixed with `form_` perform tasks that are useful when dealing with forms. The helper maps directly to the `Form` PHP class and its methods. For example:
 
     {{ form_close() }}
 
-Is the PHP equivalent of the following:
+is the PHP equivalent of the following:
 
     <?= Form::close() ?>
 
@@ -32,11 +32,11 @@ The function support the following options:
 
 Option | Description
 ------------- | -------------
-**method** | request method, corresponds the **method** FORM tag attribute. Eg: POST, GET, PUT, DELETE
-**request** | a handler name to execute on the server when the form is posted, see the [Handling forms](../cms/pages#handling-forms) article for details about the event handlers.
-**url** | specifies URL to post the form to, corresponds the **action** FORM tag attribute.
-**files** | determines whether the form will submit files, accepted values: **true** and **false**.
-**model** | a model object for the form model binding.
+**method** | Request method. Corresponds to the **method** FORM tag attribute. Eg: POST, GET, PUT, DELETE
+**request** | A handler name to execute on the server when the form is posted. See the [Handling forms](../cms/pages#handling-forms) article for details about the event handlers.
+**url** | Specifies URL to post the form to. Corresponds to the **action** FORM tag attribute.
+**files** | Determines whether the form will submit files. Accepted values: **true** and **false**.
+**model** | A model object for the form model binding.
 
 ## form_ajax()
 
@@ -64,14 +64,14 @@ Option | Description
 ------------- | -------------
 **success** | JavaScript string to execute on successful result.
 **error** | JavaScript string to execute on failed result.
-**confirm** | a message to display to confirm before sending the request.
-**redirect** | on successful result, redirect to a URL.
-**update** | an array of partials to update on success in the following format: { 'partial': '#element' }.
-**data** | extra data to include with the request in the following format: { 'myvar': 'myvalue' }.
+**confirm** | A confirmation message to display before sending the request.
+**redirect** | On successful result, redirect to a URL.
+**update** | An array of partials to update on success in the following format: { 'partial': '#element' }.
+**data** | Extra data to include with the request in the following format: { 'myvar': 'myvalue' }.
 
 ## form_close()
 
-Outputs a standard FORM closing tag. This tag is generally available to provide consistency across the usage.
+Outputs a standard FORM closing tag. This tag is generally available to provide consistency in usage.
 
     {{ form_close() }}
 

--- a/markup-function-html.md
+++ b/markup-function-html.md
@@ -1,10 +1,10 @@
 # html()
 
-Functions prefixed with `html_` perform tasks that are useful when dealing with htmls. The helper maps directly to the `Html` PHP class and its methods.
+Functions prefixed with `html_` perform tasks that are useful when dealing with html markup. The helper maps directly to the `Html` PHP class and its methods. For example:
 
     {{ html_strip() }}
 
-Is the PHP equivalent of the following:
+is the PHP equivalent of the following:
 
     <?= Html::strip() ?>
 

--- a/markup-function-str.md
+++ b/markup-function-str.md
@@ -1,10 +1,10 @@
 # str()
 
-Functions prefixed with `str_` perform tasks that are useful when dealing with strs. The helper maps directly to the `Str` PHP class and its methods.
+Functions prefixed with `str_` perform tasks that are useful when dealing with strings. The helper maps directly to the `Str` PHP class and its methods. For example:
 
     {{ str_camel() }}
 
-Is the PHP equivalent of the following:
+is the PHP equivalent of the following:
 
     <?= Str::camel() ?>
 

--- a/markup-tag-component.md
+++ b/markup-tag-component.md
@@ -11,7 +11,7 @@ This will render the component partial with a fixed name of **default.htm** and 
 <a name="variables"></a>
 ## Variables
 
-Some components support [passing variables](../cms/components#variables) at the render time:
+Some components support [passing variables](../cms/components#variables) at render time:
 
     {% component "blogPosts" postsPerPage="5" %}
 

--- a/markup-tag-flash.md
+++ b/markup-tag-flash.md
@@ -8,7 +8,7 @@ The `{% flash %}` and `{% endflash %}` tags will render any flash messages store
         {% endflash %}
     </ul>
 
-You can use the `type` variable that represents the flash message type - **success**, **error**, **info** or **warning**.
+You can use the `type` variable that represents the flash message type &mdash; **success**, **error**, **info** or **warning**.
 
     {% flash %}
         <div class="alert alert-{{ type }}">

--- a/markup-tag-for.md
+++ b/markup-tag-for.md
@@ -36,7 +36,7 @@ If you do need to iterate over a collection of numbers, you can use the `..` ope
 
 The above snippet of code would print all numbers from 0 to 10.
 
-It can be also useful with letters:
+It can also be useful with letters:
 
     {% for letter in 'a'..'z' %}
         - {{ letter }}
@@ -65,13 +65,13 @@ Inside of a `for` loop block you can access some special variables:
 Variable | Description
 ------------- | -------------
 `loop.index` | The current iteration of the loop. (1 indexed)
-`loop.index0` | he current iteration of the loop. (0 indexed)
+`loop.index0` | The current iteration of the loop. (0 indexed)
 `loop.revindex` |  The number of iterations from the end of the loop (1 indexed)
 `loop.revindex0` | The number of iterations from the end of the loop (0 indexed)
 `loop.first` | True if first iteration
 `loop.last` |  True if last iteration
-`loop.length` | he number of items in the collection
-`loop.parent` | he parent context
+`loop.length` | The number of items in the collection
+`loop.parent` | The parent context
 
     {% for user in users %}
         {{ loop.index }} - {{ user.username }}

--- a/markup-tag-placeholder.md
+++ b/markup-tag-placeholder.md
@@ -4,7 +4,7 @@ The `{% placeholder %}` tag will render a placeholder section which is generally
 
     {% placeholder name %}
 
-Content can then be injected in to the placeholder in any subsequent page or partial.
+Content can then be injected into the placeholder in any subsequent page or partial.
 
     {% put name %}
         <p>Place this text in the name placeholder</p>
@@ -13,7 +13,7 @@ Content can then be injected in to the placeholder in any subsequent page or par
 <a name="default-placeholder-content"></a>
 ## Default placeholder content
 
-Placeholders can have default content, that can be either replaced or complemented by a page. If the `{% put %}` tag for a placeholder with default content is not defined on a page, the default placeholder content is displayed. Example placeholder definition in the layout template:
+Placeholders can have default content that can be either replaced or complemented by a page. If the `{% put %}` tag for a placeholder with default content is not defined on a page, the default placeholder content is displayed. Example placeholder definition in the layout template:
 
     {% placeholder sidebar default %}
         <p><a href="/contacts">Contact us</a></p>
@@ -49,7 +49,7 @@ In a layout template you can check if a placeholder content exists by using the 
 <a name="custom-placeholder-attributes"></a>
 ## Custom attributes
 
-The `placeholder` tag accepts two optional attributes - `title` and `type`. The `title` attribute is not used by the CMS itself, but could be used by other plugins. The type attribute manages the placeholder type. There are two types supported at the moment - **text** and **html**. The content of text placeholders is escaped before it's displayed. The title and type attributes should be defined after the placeholder name and the `default` attribute, if it's presented. Example:
+The `placeholder` tag accepts two optional attributes &mdash; `title` and `type`. The `title` attribute is not used by the CMS itself, but could be used by other plugins. The type attribute manages the placeholder type. There are two types supported at the moment &mdash; **text** and **html**. The content of text placeholders is escaped before it's displayed. The title and type attributes should be defined after the placeholder name and the `default` attribute, if it's presented. Example:
 
     {% placeholder ordering title="Ordering information" type="text" %}
 

--- a/markup-tag-scripts.md
+++ b/markup-tag-scripts.md
@@ -11,7 +11,7 @@ The `{% scripts %}` tag inserts JavaScript file references to scripts injected b
 
 ## Injecting scripts
 
-Links to JavaScript files can be injected in PHP either by [components](../plugin/components#component-assets) or [pages programatically](../cms/pages#injecting-assets).
+Links to JavaScript files can be programatically injected in PHP either by [components](../plugin/components#component-assets) or [pages](../cms/pages#injecting-assets).
 
     function onStart()
     {

--- a/markup-templating.md
+++ b/markup-templating.md
@@ -83,5 +83,5 @@ There are some features offered by Twig that are not supported by October. They 
 
 Tag | Equivalent
 ------------- | -------------
-`{% extend %}` | Use Layouts or `{% placeholder %}`
+`{% extend %}` | Use [Layouts](http://octobercms.com/docs/cms/layouts) or `{% placeholder %}`
 `{% include %}` | Use `{% partial %}` or `{% content %}`

--- a/markup-this-theme.md
+++ b/markup-this-theme.md
@@ -1,8 +1,6 @@
 # this.theme
 
-You can access the current theme object via `this.theme` and it returns the object `Cms\Classes\Theme`.
-
-a reference to the [theme customization object](../themes/development#customization).
+You can access the current theme object via `this.theme` and it returns the object `Cms\Classes\Theme`, a reference to the [theme customization object](../themes/development#customization).
 
 ## Properties
 


### PR DESCRIPTION
Updated markup docs for grammar and clarity. Notes:

1. The section Filters -> `|theme` -> Combiner Aliases could be improved with example markup for the text "at least one explicit reference with a file extension is needed in the array to determine which is used".

2. The use of "Example:" and "For example:" should be made consistent.

3. References to tag etc. should have a consistent treatment. For example, on the default filter page, references to the tag appear as `|default` and conversational references to the tag should appear as `default`. Hypothetical use case, "The `default` filter defaults to...".