### PR TITLE
Wildcard parameter does not match ZERO parameters

### DIFF
--- a/cms-pages.md
+++ b/cms-pages.md
@@ -73,7 +73,7 @@ You can also use regular expressions to validate parameters. To add a validation
     ...
     url = "/blog/:post_name?|^[a-z0-9\-]+$" - this will match /blog/my-blog-post
 
-It is possible to use a special *wildcard* parameter by placing an **asterisk** after the parameter. Unlike regular parameters, wildcard parameters can match zero or more URL segments. A URL can only ever contain a single wildcard parameter, cannot use regular expressions, or be followed by an optional parameter.
+It is possible to use a special *wildcard* parameter by placing an **asterisk** after the parameter. Unlike regular parameters, wildcard parameters can match one or more URL segments. A URL can only ever contain a single wildcard parameter, cannot use regular expressions, or be followed by an optional parameter.
 
     url = "/blog/:category*/:slug"
 


### PR DESCRIPTION
Tested with

```
url = /store/category/:name*
```

URL: http://localhost:8000/store/category
Output: 404

URL: http://localhost:8000/store/category/
Output: 404