### PR TITLE
Fix link to scheduled tasks

### DIFF
--- a/plugin-registration.md
+++ b/plugin-registration.md
@@ -104,7 +104,7 @@ Method | Description
 **registerFormWidgets()** | registers any [back-end form widgets](../backend/widgets#form-widget-registration) used by this plugin.
 **registerReportWidgets()** | registers any [back-end report widgets](../backend/widgets#report-widget-registration), including the dashboard widgets.
 **registerMailTemplates()** | registers any [mail view templates](mail#mail-template-registration) supplied by this plugin.
-**registerSchedule()** | registers [scheduled tasks](#scheduling) that are executed on a regular basis.
+**registerSchedule()** | registers [scheduled tasks](../plugin/scheduling#defining-schedules) that are executed on a regular basis.
 
 <a name="basic-plugin-information"></a>
 ### Basic plugin information


### PR DESCRIPTION
Fix link to scheduled tasks. Section #scheduling has been removed by https://github.com/octobercms/docs/commit/770ea2161d8e205934885b469e2dacab8e78f8cb