### PR TITLE
Remove unsupported method for schedule frequency

### DIFF
--- a/plugin-scheduling.md
+++ b/plugin-scheduling.md
@@ -49,7 +49,6 @@ Of course, there are a variety of schedules you may assign to your task:
 Method  | Description
 ------------- | -------------
 `->cron('* * * * *');`  |  Run the task on a custom Cron schedule
-`->everyMinute();`  |  Run the task every minute
 `->everyFiveMinutes();`  |  Run the task every five minutes
 `->everyTenMinutes();`  |  Run the task every ten minutes
 `->everyThirtyMinutes();`  |  Run the task every thirty minutes


### PR DESCRIPTION
`everyMinute()` was introduced in Laravel 5.1
