### PR TITLE
Make plugin/component examples match the rest

### DIFF
--- a/console-scaffolding.md
+++ b/console-scaffolding.md
@@ -13,21 +13,21 @@ Use the scaffolding commands to speed up the development process.
 
 `create:plugin` - generates a plugin folder and basic files for the plugin. The parameter specifies the author and plugin name.
 
-    php artisan create:plugin Foo.Bar
+    php artisan create:plugin Acme.Blog
 
 `create:component` - creates a new component class and the default component view. The first parameter specifies the author and plugin name. The second parameter specifies the component class name.
 
-    php artisan create:component Foo.Bar Post
+    php artisan create:component Acme.Blog Post
 
 `create:model` - generates files needed for a new model. The first parameter specifies the author and plugin name. The second parameter specifies the model class name.
 
-    php artisan create:model RainLab.Blog Post
+    php artisan create:model Acme.Blog Post
 
 `create:controller` - generates a controller, configuration and view files. The first parameter specifies the author and plugin name. The second parameter specifies the controller class name.
 
-    php artisan create:controller RainLab.Blog Posts
+    php artisan create:controller Acme.Blog Posts
 
 `create:formwidget` - generates a back-end form widget, view and basic asset files. The first parameter specifies the author and plugin name. The second parameter specifies the form widget class name.
 
-    php artisan create:formwidget RainLab.Blog CategorySelector
+    php artisan create:formwidget Acme.Blog CategorySelector
 


### PR DESCRIPTION
Foo.Bar isn't very descriptive, and all the other examples are already using `RainLab.Blog` anyway. This updates the remaining `Foo.Bar` examples to match the others.