### PR TITLE
Document the SORT_ORDER constant

### DIFF
--- a/database-traits.md
+++ b/database-traits.md
@@ -142,7 +142,7 @@ The revision history can be accessed like any other relation:
 <a name="sortable"></a>
 ## Sortable
 
-Sorted models will store a number value in `sort_order` which maintains the sort order of each individual model in a collection. To store a sort order for your models, apply the `October\Rain\Database\Traits\Sortable` trait and ensure that your schema has a column defined for it to use (example: ``$table->integer('sort_order')->default(0);``).
+Sorted models will store a number value in `sort_order` which maintains the sort order of each individual model in a collection. To store a sort order for your models, apply the `October\Rain\Database\Traits\Sortable` trait and ensure that your schema has a column defined for it to use (example: `$table->integer('sort_order')->default(0);`).
 
     class User extends Model
     {

--- a/database-traits.md
+++ b/database-traits.md
@@ -142,12 +142,17 @@ The revision history can be accessed like any other relation:
 <a name="sortable"></a>
 ## Sortable
 
-Sorted models will store a number value in `sort_order` which maintains the sort order of each individual model in a collection. The store a sort order for your models, apply the `October\Rain\Database\Traits\Sortable` trait.
+Sorted models will store a number value in `sort_order` which maintains the sort order of each individual model in a collection. To store a sort order for your models, apply the `October\Rain\Database\Traits\Sortable` trait and ensure that your schema has a column defined for it to use (example: ``$table->integer('sort_order')->default(0);``).
 
     class User extends Model
     {
         use \October\Rain\Database\Traits\Sortable;
     }
+    
+
+You may modify the key name used to identify the sort order by defining the `SORT_ORDER` constant:
+
+    const SORT_ORDER = 'my_sort_order_column';
 
 Use the `setSortableOrder` method to set the orders on a single record or multiple records.
 


### PR DESCRIPTION
Adds info on the overridable SORT_ORDER constant utilized by the Sortable trait to identify which attribute on the model holds the sort order and provides a minor grammatical fix ("The store a sort order" to "To store a sort order").