### PR TITLE
Unclear docs for nginx configuration and proposed fix

### DIFF
--- a/setup-configuration.md
+++ b/setup-configuration.md
@@ -52,7 +52,7 @@ There are small changes required to configure your site in Nginx.
 Use the following code in **server** section. If you have installed October into a subdirectory, replace `/` with the directory October was installed under:
 
     location / {
-        try_files $uri $uri/ /index.php$is_args$args;
+        try_files $uri /index.php$is_args$args;
     }
 
     rewrite ^themes/.*/(layouts|pages|partials)/.*.htm /index.php break;


### PR DESCRIPTION
# Fixing `nginx` configuration

Docs section responsible for `nginx` configuration section are incorrect. 

```
location / {
    try_files $uri $uri/ /index.php$is_args$args;
}
```

is causing: 

```
directory index of "<local_directory_path>" is forbidden
```

Removing `$uri/` (directory option) fixes the problem. 

This has been tested and confirmed on docker multi-container setup with `php:7.0-fpm` and `debian:jessie` with latest `nginx` installed.

That said it's worth mentioning that docs are not showing full `.conf` file. 
On my server full config looks like this:

```
server {
    server_name <domain.com>;
    root /var/www/pg/;

    location / {
        try_files $uri /index.php$is_args$args;
    }

    location  ~ \.php$ {
        index index.php;
        fastcgi_pass php-upstream;
        fastcgi_split_path_info ^(.+\.php)(/.*)$;
        include fastcgi_params;
        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
        fastcgi_param HTTPS off;
    }

    rewrite ^themes/.*/(layouts|pages|partials)/.*.htm /index.php break;
    rewrite ^bootstrap/.* /index.php break;
    rewrite ^config/.* /index.php break;
    rewrite ^vendor/.* /index.php break;
    rewrite ^storage/cms/.* /index.php break;
    rewrite ^storage/logs/.* /index.php break;
    rewrite ^storage/framework/.* /index.php break;
    rewrite ^storage/temp/protected/.* /index.php break;
    rewrite ^storage/app/uploads/protected/.* /index.php break;

    error_log /var/log/nginx/error.log;
    access_log /var/log/nginx/access.log;
}
```

This PR is also partially related to #142 issue. 

