### PR TITLE
Update setting file path to the data attribute

### DIFF
--- a/database-attachments.md
+++ b/database-attachments.md
@@ -40,7 +40,7 @@ For singular attach relations (`$attachOne`), you may create an attachment direc
 
 You may also pass a string to the `data` attribute that contains an absolute path to a local file.
 
-    $model->avatar = '/path/to/somefile.jpg';
+    $model->avatar->data = '/path/to/somefile.jpg';
 
 For multiple attach relations (`$attachMany`), you may use the `create()` method on the relationship instead, notice the file object is assocated to the `data` attribute. This approach can be used for singular relations too, if you prefer.
 


### PR DESCRIPTION
Many users may mistakenly try to set the file path to the file model itself, like [here](http://stackoverflow.com/q/42428973/69537):

    $product->image = '/path/image.png';
    $product->save();

But it has to be:

    $product->image->data = '/path/image.png';