### PR TITLE
Document new methods for extending filter scopes

### DIFF
--- a/backend-lists.md
+++ b/backend-lists.md
@@ -553,7 +553,7 @@ Using the `extendfilterScopes` method you can add and remove filter scopes to an
 
         Categories::extendListColumns(function($filter) {
             $filter->addScopes([
-                'my_filter_scope' => [
+                'my_scope' => [
                     'label' => 'My Filter Scope'
                 ]
             ]);
@@ -578,7 +578,7 @@ Method | Description
 ------------- | -------------
 **addScopes** | adds new scopes to filter widget
 
-Each method takes an array of columns similar to the [list filters configuration](#list-filters).
+Each method takes an array of scopes similar to the [list filters configuration](#list-filters).
 
 
 <a name="extend-model-query"></a>

--- a/backend-lists.md
+++ b/backend-lists.md
@@ -16,6 +16,7 @@
     - [Overriding controller action](#overriding-action)
     - [Overriding views](#overriding-views)
     - [Extending column definitions](#extend-list-columns)
+    - [Extending filter scopes](#extend-filter-scopes)
     - [Extending the model query](#extend-model-query)
     - [Extending the records collection](#extend-records-collection)
     - [Custom column types](#custom-column-types)
@@ -432,6 +433,7 @@ Sometimes you may wish to modify the default list behavior and there are several
 - [Overriding controller action](#overriding-action)
 - [Overriding views](#overriding-views)
 - [Extending column definitions](#extend-list-columns)
+- [Extending filter scopes](#extend-filter-scopes)
 - [Extending the model query](#extend-model-query)
 - [Custom column types](#custom-column-types)
 
@@ -534,6 +536,50 @@ Method | Description
 **removeColumn** | removes a column from the list
 
 Each method takes an array of columns similar to the [list column configuration](#list-columns).
+
+<a name="extend-filter-scopes"></a>
+### Extending filter scopes
+
+You can extend the filter scopes of another controller from outside by calling the `extendFilterScopes` static method on the controller class. This method can take the argument **$filter** which will represent the Filter widget object. Take this controller for example:
+
+    class Categories extends \Backend\Classes\Controller
+    {
+        public $implement = ['Backend.Behaviors.ListController'];
+
+        public $listConfig = 'list_config.yaml';
+    }
+
+Using the `extendfilterScopes` method you can add and remove filter scopes to any list rendered by this controller. Here is an example:
+
+        Categories::extendListColumns(function($filter) {
+            $filter->addScopes([
+                'my_filter_scope' => [
+                    'label' => 'My Filter Scope'
+                ]
+            ]);
+
+        });
+
+You can also extend the lists filter scopes internally by overriding the `filterExtendScopes` method inside the controller class.
+
+    class Categories extends \Backend\Classes\Controller
+    {
+        [...]
+
+        public function filterExtendScopes($filter)
+        {
+            $filter->addScopes([...]);
+        }
+    }
+
+The following methods are available on the $filter object.
+
+Method | Description
+------------- | -------------
+**addScopes** | adds new scopes to filter widget
+
+Each method takes an array of columns similar to the [list filters configuration](#list-filters).
+
 
 <a name="extend-model-query"></a>
 ### Extending the model query


### PR DESCRIPTION
I don't know why this one code line with the definition array is displayed wrongly, probably something stupid.