### PR TITLE
Fix wrong number of arguments in callback for first().

### DIFF
--- a/database-collection.md
+++ b/database-collection.md
@@ -53,7 +53,7 @@ Collections may also be converted to a PHP array or JSON:
 
 The `first` method will return the first object that matches the condition.
 
-    $found = $collection->first(function($model) {
+    $found = $collection->first(function($key, $model) {
         return $model->color == 'red';
     });
 


### PR DESCRIPTION
The callback function passed to `Collection#first` method is invoked in `Arr#first` method with `call_user_func` function given the array key and value.