### PR TITLE
Fix Form::ajax example

### DIFF
--- a/services-html.md
+++ b/services-html.md
@@ -67,8 +67,8 @@ The second argument of `Form::ajax` should contain the attributes:
 You can also pass partials to update as another array:
 
     Form::ajax('onSave', ['update' => [
-            'control-panel': '#controlPanel',
-            'layout/sidebar': '#layoutSidebar'
+            'control-panel' => '#controlPanel',
+            'layout/sidebar' => '#layoutSidebar'
         ]
     ])
 


### PR DESCRIPTION
Hi @daftspunk!
Here is the small fix.
When you copy and paste 
```
Form::ajax('onSave', ['update' => [
        'control-panel': '#controlPanel',
        'layout/sidebar': '#layoutSidebar'
    ]
])
``` 
There is a syntax error;