### PR TITLE
Updated trigger events parent level reference

### DIFF
--- a/backend-forms.md
+++ b/backend-forms.md
@@ -952,7 +952,7 @@ In the above example the `send_at` form field will only be shown if the `is_dela
 Option | Description
 ------------- | -------------
 **action** | defines the action applied to this field when the condition is met. Supported values: show, hide, enable, disable, empty.
-**field** | defines the other field name that will trigger the action.
+**field** | defines the other field name that will trigger the action. Normally the field name refers to a field in the same level form. For example, if this field is in a [repeater widget](#widget-repeater), only fields in that same [repeater widget](#widget-repeater) will be checked. However, if the field name is preceeded by a caret symbol `^` like: `^parent_field`, it will refer to a [repeater widget](#widget-repeater) or form one level higher than the field itself. Additionally, if more than one caret `^` is used, it will refer that many levels higher: `^^grand_parent_field`, `^^^grand_grand_parent_field`, etc.
 **condition** | determines the condition the specified field should satisfy for the condition to be considered "true". Supported values: checked, unchecked, value[somevalue].
 
 <a name="field-dependencies"></a>


### PR DESCRIPTION
Updated trigger events parent level reference with a description how to use a caret ^ symbol to reference higher level forms

Update from [#3465](https://github.com/octobercms/october/pull/3465)