### PR TITLE
Supervisor Configuration

### DIFF
--- a/services-queues.md
+++ b/services-queues.md
@@ -195,7 +195,7 @@ Supervisor configuration files are typically stored in the `/etc/supervisor/conf
     redirect_stderr=true
     stdout_logfile=/path/to/october/worker.log
     
-In this example, the `numprocs` directive will instruct Supervisor to run 8 `queue:work` processes and monitor all of them, automatically restarting them if they fail. Of course, you should change the `queue:work` portion of the command directive to reflect your desired queue connection.
+In this example, the `numprocs` directive will instruct Supervisor to run 8 `queue:work` processes and monitor all of them, automatically restarting them if they fail. Of course, you should change the `queue:work` portion of the command directive to reflect your desired queue connection. The `user` directive should be changed to the name of a user that has permission to run the command.
 
 ### Starting Supervisor
 

--- a/services-queues.md
+++ b/services-queues.md
@@ -172,13 +172,6 @@ In addition, you may specify the number of seconds to wait before polling for ne
 
 Note that the queue only "sleeps" if no jobs are on the queue. If more jobs are available, the queue will continue to work them without sleeping.
 
-<a name="daemon-queue-worker"></a>
-## Daemon queue worker
-
-The `queue:work` also includes a `--daemon` option for forcing the queue worker to continue processing jobs without ever re-booting the framework. This results in a significant reduction of CPU usage when compared to the `queue:work` command, but at the added complexity of needing to drain the queues of currently executing jobs during your deployments.
-
-To start a queue worker in daemon mode, use the `--daemon` flag:
-
 <a name="supervisor-configuration"></a>
 ## Supervisor configuration
 

--- a/services-queues.md
+++ b/services-queues.md
@@ -179,32 +179,6 @@ The `queue:work` also includes a `--daemon` option for forcing the queue worker 
 
 To start a queue worker in daemon mode, use the `--daemon` flag:
 
-    php artisan queue:work connection --daemon
-
-    php artisan queue:work connection --daemon --sleep=3
-
-    php artisan queue:work connection --daemon --sleep=3 --tries=3
-
-You may use the `php artisan help queue:work` command to view all of the available options.
-
-### Deploying with daemon queue workers
-
-The simplest way to deploy an application using daemon queue workers is to put the application in maintenance mode at the beginning of your deployment. This can be done using the back-end settings area. Once the application is in maintenance mode, October will not accept any new jobs off of the queue, but will continue to process existing jobs.
-
-The easiest way to restart your workers is to include the following command in your deployment script:
-
-    php artisan queue:restart
-
-This command will instruct all queue workers to restart after they finish processing their current job.
-
-> **Note:** This command relies on the cache system to schedule the restart. By default, APCu does not work for CLI commands. If you are using APCu, add `apc.enable_cli=1` to your APCu configuration.
-
-### Coding for daemon queue workers
-
-Daemon queue workers do not restart the platform before processing each job. Therefore, you should be careful to free any heavy resources before your job finishes. For example, if you are doing image manipulation with the GD library, you should free the memory with `imagedestroy` when you are done.
-
-Similarly, your database connection may disconnect when being used by long-running daemon. You may use the `Db::reconnect` method to ensure you have a fresh connection.
-
 <a name="supervisor-configuration"></a>
 ## Supervisor configuration
 


### PR DESCRIPTION
Add a section to `/services/queues` about how to configure Supervisor to ensure the queue worker is running at all times.