### PR TITLE
Update services-behaviors.md mergeConfig reference

### DIFF
--- a/services-behaviors.md
+++ b/services-behaviors.md
@@ -213,7 +213,7 @@ Below is an example of dynamically extending a `UsersController` of a third-part
         // Splice in configuration safely
         $myConfigPath = '$/myvendor/myplugin/controllers/users/config_relation.yaml';
 
-        $controller->relationConfig = $this->mergeConfig(
+        $controller->relationConfig = $controller->mergeConfig(
             $controller->relationConfig,
             $myConfigPath
         );


### PR DESCRIPTION
In this documenation block, specifically the `Detecting utilized extensions` part, the text refers to `$this->mergeConfig()`. This will most likely throw an error. The reference to `$this` is only valid if the extension is done inside another controller, which is not the place where you would extend the controller.

By using the `$controller` reference, it is made sure that the `mergeConfig` method is always available. This is backed up by the answer on octobercms/october#3105