### PR TITLE
Updated registerMailTemplates to new syntax

### DIFF
--- a/services-mail.md
+++ b/services-mail.md
@@ -354,12 +354,12 @@ Mail views can be registered as templates that are automatically generated in th
     public function registerMailTemplates()
     {
         return [
-            'rainlab.user::mail.activate' => 'Activation mail sent to new users.',
-            'rainlab.user::mail.restore'  => 'Password reset instructions for front-end users.'
+            'rainlab.user::mail.activate',
+            'rainlab.user::mail.restore'
         ];
     }
 
-The method should return an array where the key is the [mail view name](#mail-views) and the value gives a brief description about what the mail template is used for.
+The method should return an array of [mail view names](#mail-views).
 
 <a name="mail-global-variables"></a>
 ### Global variables


### PR DESCRIPTION
The description for a mail templates can no longer be specified in registerMailTemplates
method. It is possible to add a new "description" property to the configuration section
in the template itself.

@see https://github.com/octobercms/october/commit/4663531de211a9e621a74b1be60460527a748483