### PR TITLE
removed unnecessary line

### DIFF
--- a/backend-widgets.md
+++ b/backend-widgets.md
@@ -74,8 +74,6 @@ Alternatively you may pass the variables to the second parameter of the makePart
 
     public function render()
     {
-        $this->vars['var'] = $value;
-
         return $this->makePartial('list', ['var' => 'value']);
     }
 


### PR DESCRIPTION
Since `vars` may be passed as a second argument of `makePartial`, we do not need to set them before. There is no reason to do `$this->vars['var'] = 'value';` in such case.