### PR TITLE
Clarify implementation of custom validation rules in plugins

### DIFF
--- a/services-validation.md
+++ b/services-validation.md
@@ -654,7 +654,16 @@ When creating a custom validation rule, you may sometimes need to define custom 
     public function boot()
     {
         Validator::replacer('foo', function ($message, $attribute, $rule, $parameters) {
-            return str_replace(...);
+            // return a message as a string
+        });
+    }
+
+The callback receives 4 arguments: `$message` being the message returned by the validator, `$attribute` being the attribute which failed validation, `$rule` being the rule object and `$parameters` being the parameters defined with the validation rule. You may, for example, inject a column name into the message that was defined in the parameters:
+
+    public function boot()
+    {
+        Validator::replacer('foo', function ($message, $attribute, $rule, $parameters) {
+            return str_replace(':column', $parameters[0], $message);
         });
     }
 
@@ -662,7 +671,6 @@ If you wish to support multiple languages with your error messages, you will nee
 
     public function boot()
     {
-        //
         Event::listen('translator.beforeResolve', function ($key, $replaces, $locale) {
             if ($key === 'validation.uppercase') {
                 return Lang::get('plugin.name::lang.validation.uppercase');

--- a/services-validation.md
+++ b/services-validation.md
@@ -598,35 +598,35 @@ A `Rule` object represents a single reusable validation rule for your models tha
     class Uppercase implements Rule
     {
         /**
-        * Determine if the validation rule passes.
-        *
-        * @param  string  $attribute
-        * @param  mixed  $value
-        * @return bool
-        */
+         * Determine if the validation rule passes.
+         *
+         * @param  string  $attribute
+         * @param  mixed  $value
+         * @return bool
+         */
         public function passes($attribute, $value)
         {
             return strtoupper($value) === $value;
         }
 
         /**
-        * Validation callback method.
-        *
-        * @param  string  $attribute
-        * @param  mixed  $value
-        * @param  array  $params
-        * @return bool
-        */
+         * Validation callback method.
+         *
+         * @param  string  $attribute
+         * @param  mixed  $value
+         * @param  array  $params
+         * @return bool
+         */
         public function validate($attribute, $value, $params)
         {
             return $this->passes($attribute, $value);
         }
 
         /**
-        * Get the validation error message.
-        *
-        * @return string
-        */
+         * Get the validation error message.
+         *
+         * @return string
+         */
         public function message()
         {
             return 'The :attribute must be uppercase.';


### PR DESCRIPTION
Updates the [Custom Validation Rules](https://octobercms.com/docs/services/validation#custom-validation-rules) section of the Validation docs page to clarify how to implement custom validation rules in plugins.