### PR TITLE
Added directory structure example for Form Widgets

### DIFF
--- a/backend-widgets.md
+++ b/backend-widgets.md
@@ -114,6 +114,19 @@ After binding the widget you can access it in the controller's view or partial b
 
 With form widgets you can add new control types to the back-end [forms](../backend/forms). They provide features that are common to supplying data for models. Form widgets must be registered in the [Plugin registration file](../plugin/registration#registration-methods).
 
+Form Widget classes reside inside the **formwidgets** directory of the plugin directory. The directory name matches the name of the widget class written in lowercase. Widgets can supply assets and partials. An example form widget directory structure looks like this:
+
+    formwidgets/
+      /form
+        /partials
+          _form.htm     <=== Widget partial file
+        /assets
+          /js
+            form.js     <=== Widget JavaScript file
+          /css
+            form.css    <=== Widget StyleSheet file
+      Form.php          <=== Widget class
+
 <a name="form-class-definition"></a>
 ### Class definition
 


### PR DESCRIPTION
I've added an example directory structure for form widgets so that it is clear that you need a separate directory for form widgets. I was a bit confused and on a clock when I tried to create my own Form Widget and after failing several times, I resorted to looking at some sample code.
The Docs don't make it clear that you need a separate folder, and by adding this block, there is no more doubt about it.
