### PR TITLE
Document form attribute markup for components

### DIFF
--- a/markup-function-form.md
+++ b/markup-function-form.md
@@ -58,6 +58,11 @@ There are some special options that can also be used alongside the attributes.
 
     {{ form_ajax('onRefresh', { update: { statistics: '#statsPanel' } }) }}
 
+To update component partials a variable must first be set like so:
+
+    {% set updateAttrib = "'" ~ __SELF__ ~ "::statistics': '#statsPanel'" %}
+    {{ form_ajax('onUpdate', { update: updateAttrib }) }}
+
 The function support the following options:
 
 Option | Description


### PR DESCRIPTION
Component partials can't be passed to form_ajax() in the same way regular partials can. Attempting to use something along the lines of
```
{{ form_ajax('onUpdate', {update: {__SELF__~'::statistics': '#statsPanel'}}) }}
```
Results in the error:
> A hash key must be followed by a colon (:). Unexpected token "operator" of value "~" ("punctuation" expected with value ":").

For components a Twig variable must first be set then used like so:
```
{% set updateAttrib = "'" ~ __SELF__ ~ "::statistics': '#statsPanel'" %}
{{ form_ajax('onUpdate', { update: updateAttrib }) }}
```