### PR TITLE
Add notes about using a public folder

### DIFF
--- a/setup-configuration.md
+++ b/setup-configuration.md
@@ -291,3 +291,5 @@ This will create an **.env** file in project root directory and modify configura
     'debug' => env('APP_DEBUG', true),
 
 Your `.env` file should not be committed to your application's source control, since each developer or server using your application could require a different environment configuration.
+
+It is also important that your `.env` file is not accessible to the public in production. To accomplish this, you should consider using a [public folder](#public-folder).

--- a/setup-installation.md
+++ b/setup-installation.md
@@ -81,7 +81,7 @@ Configuration files are stored in the **config** directory of the application. W
 
 For example, in production environments you may want to enable [CSRF protection](../setup/configuration#csrf-protection). While in development environments, you may want to enable [bleeding edge updates](../setup/configuration#edge-updates).
 
-While most configuration is optional, we strongly recommend disabling [debug mode](../setup/configuration#debug-mode) for production environments.
+While most configuration is optional, we strongly recommend disabling [debug mode](../setup/configuration#debug-mode) for production environments. You may also want to use a [public folder](../setup/configuration#public-folder) for additional security.
 
 <a name="crontab-setup"></a>
 ### Setting up the scheduler


### PR DESCRIPTION
Since October does not use a public folder by default, I think it is important to note that it is recommended for a secure production installation, particularly when using DotEnv configuration.

Personally, I had been running a production site where .env was accidentally available for download because I didn't think about it (coming from a straight Laravel background).