### PR TITLE
Update belongsToMany with Pivot data note

### DIFF
--- a/backend-relations.md
+++ b/backend-relations.md
@@ -167,6 +167,8 @@ For example, if a *User* belongs to many *Roles*, the target model is set as the
 <a name="belongs-to-many-pivot"></a>
 ### Belongs to many (with Pivot Data)
 
+> **Note:** Pivot data is not supported by [deferred bindings](../database/relations#deferred-binding) at this time, so the parent model should exist. If your relation behavior config has `deferredBinding: true`, the pivot data will **not** be available to use in the list configuration (ex.`pivot[attribute]`).
+
 1. Related records are displayed as a list (**view.list**).
 1. Clicking a record will display an update form (**pivot.form**).
 1. Clicking *Add* will display a selection list (**manage.list**), then a data entry form (**pivot.form**).
@@ -212,8 +214,6 @@ Pivot data is available when defining form fields and list columns via the `pivo
                 fields:
                     pivot[team_color]:
                         label: Team color
-
-> **Note:** Pivot data is not supported by [deferred bindings](../database/relations#deferred-binding) at this time, so the parent model should exist.
 
 <a name="belongs-to"></a>
 ### Belongs to


### PR DESCRIPTION
The current documentation is slightly ambiguous when describing the consequences of enabling `deferredBinding` in the relation behavior config for belongsToMany with Pivot data. This PR updates the note to include more details, and also moves it to the top of the Belongs to many (with pivot data) section so that it is more relevant.