### PR TITLE
Fix 301 redirection and anchors links on backend-ajax links

### DIFF
--- a/backend-forms.md
+++ b/backend-forms.md
@@ -48,7 +48,7 @@ Form behavior depends on form [field definitions](#form-fields) and a [model cla
 <a name="configuring-form"></a>
 ## Configuring the form behavior
 
-The configuration file referred in the `$formConfig` property is defined in YAML format. The file should be placed into the controller's [views directory](controllers-views-ajax/#introduction). Below is an example of a typical form behavior configuration file:
+The configuration file referred in the `$formConfig` property is defined in YAML format. The file should be placed into the controller's [views directory](controllers-ajax/#introduction). Below is an example of a typical form behavior configuration file:
 
     # ===================================
     #  Form Behavior Config

--- a/backend-import-export.md
+++ b/backend-import-export.md
@@ -37,7 +37,7 @@ The behavior configuration is defined in two parts, each part depends on a speci
 <a name="configuring-import-export"></a>
 ## Configuring the behavior
 
-The configuration file referred in the `$importExportConfig` property is defined in YAML format. The file should be placed into the controller's [views directory](controllers-views-ajax/#introduction). Below is an example of a configuration file:
+The configuration file referred in the `$importExportConfig` property is defined in YAML format. The file should be placed into the controller's [views directory](controllers-ajax/#introduction). Below is an example of a configuration file:
 
     # ===================================
     #  Import/Export Behavior Config
@@ -128,7 +128,7 @@ Option | Description
 <a name="import-export-views"></a>
 ## Import and export views
 
-For each page feature [Import](#import-page) and [Export](#export-page) you should provide a [view file](controllers-views-ajax/#introduction) with the corresponding name - **import.htm** and **export.htm**.
+For each page feature [Import](#import-page) and [Export](#export-page) you should provide a [view file](controllers-ajax/#introduction) with the corresponding name - **import.htm** and **export.htm**.
 
 The import/export behavior adds two methods to the controller class: `importRender` and `exportRender`. These methods render the importing and exporting sections as per the YAML configuration file described above.
 

--- a/backend-lists.md
+++ b/backend-lists.md
@@ -43,7 +43,7 @@ List behavior depends on list [column definitions](#list-columns) and a [model c
 <a name="configuring-list"></a>
 ## Configuring the list behavior
 
-The configuration file referred in the `$listConfig` property is defined in YAML format. The file should be placed into the controller's [views directory](controllers-views-ajax/#introduction). Below is an example of a typical list behavior configuration file:
+The configuration file referred in the `$listConfig` property is defined in YAML format. The file should be placed into the controller's [views directory](controllers-ajax/#introduction). Below is an example of a typical list behavior configuration file:
 
     # ===================================
     #  List Behavior Config
@@ -368,7 +368,7 @@ To display a column that shows the number of related records, use the `useRelati
 <a name="displaying-list"></a>
 ## Displaying the list
 
-Usually lists are displayed in the index [view](controllers-views-ajax/#introduction) file. Since lists include the toolbar, the view file will consist solely of the single `listRender` method call.
+Usually lists are displayed in the index [view](controllers-ajax/#introduction) file. Since lists include the toolbar, the view file will consist solely of the single `listRender` method call.
 
     <?= $this->listRender() ?>
 

--- a/backend-relations.md
+++ b/backend-relations.md
@@ -36,7 +36,7 @@ Relation behavior depends on [relation definitions](#relation-definitions). In o
 <a name="configuring-relation"></a>
 ## Configuring the relation behavior
 
-The configuration file referred in the `$relationConfig` property is defined in YAML format. The file should be placed into the controller's [views directory](controllers-views-ajax/#introduction). The required configuration depends on the [relationship type](#relationship-types) between the target model and the related model.
+The configuration file referred in the `$relationConfig` property is defined in YAML format. The file should be placed into the controller's [views directory](controllers-ajax/#introduction). The required configuration depends on the [relationship type](#relationship-types) between the target model and the related model.
 
 The first level field in the relation configuration file defines the relationship name in the target model. For example:
 

--- a/backend-reorder.md
+++ b/backend-reorder.md
@@ -34,7 +34,7 @@ In order to use the reorder behavior you should add it to the `$implement` prope
 <a name="configuring-reorder"></a>
 ## Configuring the behavior
 
-The configuration file referred in the `$reorderConfig` property is defined in YAML format. The file should be placed into the controller's [views directory](controllers-views-ajax/#introduction). Below is an example of a configuration file:
+The configuration file referred in the `$reorderConfig` property is defined in YAML format. The file should be placed into the controller's [views directory](controllers-ajax/#introduction). Below is an example of a configuration file:
 
 	# ===================================
 	#  Reorder Behavior Config
@@ -67,7 +67,7 @@ Option | Description
 <a name="reorder-display"></a>
 ## Displaying the reorder page
 
-You should provide a [view file](controllers-views-ajax/#introduction) with the name **reorder.htm**. This view represents the Reorder page that allows users to reorder records. Since reordering includes the toolbar, the view file will consist solely of the single `reorderRender` method call.
+You should provide a [view file](controllers-ajax/#introduction) with the name **reorder.htm**. This view represents the Reorder page that allows users to reorder records. Since reordering includes the toolbar, the view file will consist solely of the single `reorderRender` method call.
 
     <?= $this->reorderRender() ?>
     

--- a/backend-widgets.md
+++ b/backend-widgets.md
@@ -80,7 +80,7 @@ Alternatively you may pass the variables to the second parameter of the makePart
 <a name="generic-ajax-handlers"></a>
 ### AJAX handlers
 
-Widgets implement the same AJAX approach as the [back-end controllers](controllers-views-ajax#ajax). The AJAX handlers are public methods of the widget class with names starting with the **on** prefix. The only difference between the widget AJAX handlers and backend controller's AJAX handlers is that you should use the widget's `getEventHandler` method to return the widget's handler name when you refer to it in the widget partials.
+Widgets implement the same AJAX approach as the [back-end controllers](controllers-ajax#ajax). The AJAX handlers are public methods of the widget class with names starting with the **on** prefix. The only difference between the widget AJAX handlers and backend controller's AJAX handlers is that you should use the widget's `getEventHandler` method to return the widget's handler name when you refer to it in the widget partials.
 
     <a
         href="javascript:;"
@@ -94,7 +94,7 @@ When called from a widget class or partial the AJAX handler will target itself. 
 <a name="generic-binding"></a>
 ### Binding widgets to controllers
 
-A widget should be bound to a [back-end controller](controllers-views-ajax) before you can start using it in a back-end page or partial. Use the widget's `bindToController` method for binding it to a controller. The best place to initialize a widget is the controller's constructor. Example:
+A widget should be bound to a [back-end controller](controllers-ajax) before you can start using it in a back-end page or partial. Use the widget's `bindToController` method for binding it to a controller. The best place to initialize a widget is the controller's constructor. Example:
 
     public function __construct()
     {

--- a/plugin-registration.md
+++ b/plugin-registration.md
@@ -23,7 +23,7 @@ Plugins are the foundation for adding new features to the CMS by extending it. T
 1. Add [settings pages](settings#backend-pages), [menu items](#navigation-menus), [lists](../backend/lists) and [forms](../backend/forms).
 1. Create [database table structures and seed data](updates).
 1. Alter [functionality of the core or other plugins](events).
-1. Provide classes, [back-end controllers](../backend/controllers-views-ajax), views, assets, and other files.
+1. Provide classes, [back-end controllers](../backend/controllers-ajax), views, assets, and other files.
 
 <a name="directory-structure"></a>
 ### Directory structure

--- a/plugin-settings.md
+++ b/plugin-settings.md
@@ -135,7 +135,7 @@ The optional `keywords` parameter is used by the settings search feature. If key
 <a name="settings-page-context"></a>
 ### Setting the page navigation context
 
-Just like [setting navigation context in the controller](../backend/controllers-views-ajax#navigation-context), Back-end settings pages should set the settings navigation context. It's required in order to mark the current settings link in the System page sidebar as active. Use the `System\Classes\SettingsManager` class to set the settings context. Usually it could be done in the controller constructor:
+Just like [setting navigation context in the controller](../backend/controllers-ajax#navigation-context), Back-end settings pages should set the settings navigation context. It's required in order to mark the current settings link in the System page sidebar as active. Use the `System\Classes\SettingsManager` class to set the settings context. Usually it could be done in the controller constructor:
 
     public function __construct()
     {

--- a/services-router.md
+++ b/services-router.md
@@ -15,7 +15,7 @@
 <a name="basic-routing"></a>
 ## Basic routing
 
-While routing is handled automatically for the [backend controllers](../backend/controllers-views-ajax) and CMS pages define their own URL routes in their [page configuration](../cms/pages#configuration), the router service is useful primarily for defining fixed APIs and end points. 
+While routing is handled automatically for the [backend controllers](../backend/controllers-ajax) and CMS pages define their own URL routes in their [page configuration](../cms/pages#configuration), the router service is useful primarily for defining fixed APIs and end points. 
 
 You can define these routes by creating a file named **routes.php** in a same directory as the [plugin registration file](../plugin/registration). The most basic routes simply accept a URI and a `Closure`:
 


### PR DESCRIPTION
Like the previous one: it works but add consistency: some links to backend-ajax pass through a 301 redirection, which breaks the link's anchor and display a "Moved permanently" message.