### PR TITLE
update outdated options list methods

### DIFF
--- a/backend-forms.md
+++ b/backend-forms.md
@@ -445,7 +445,7 @@ The fifth method allows you to specify a static method on a class to return the 
     status:
         label: Blog Post Status
         type: dropdown
-        options: FormHelper::staticMethodOptions
+        options: \MyAuthor\MyPlugin\Classes\FormHelper::staticMethodOptions
 
 Supplying the dropdown options to the model class:
 

--- a/backend-forms.md
+++ b/backend-forms.md
@@ -459,7 +459,7 @@ The sixth method allows you to specify a callable object via an array definition
     status:
         label: Blog Post Status
         type: dropdown
-        options: [FormHelper, staticMethodOptions]
+        options: [\MyAuthor\MyPlugin\ClassesFormHelper, staticMethodOptions]
 
 Supplying the dropdown options to the model class:
 

--- a/backend-forms.md
+++ b/backend-forms.md
@@ -470,7 +470,7 @@ Radio lists can also support a secondary description.
             registered: [Registered only, Only logged in member will be able to access this page.]
             guests: [Guests only, Only guest users will be able to access this page.]
 
-Radio lists support three ways of defining the options, exactly like the [dropdown field type](#field-dropdown). For radio lists the method could return either the simple array: **key => value** or an array of arrays for providing the descriptions: **key => [label, description]**. Options can be displayed inline with each other instead of in separate rows by specifying `cssClass: 'inline-options'` on the radio field config.
+Radio lists support the same methods for defining the options as the [dropdown field type](#field-dropdown). For radio lists the method could return either the simple array: **key => value** or an array of arrays for providing the descriptions: **key => [label, description]**. Options can be displayed inline with each other instead of in separate rows by specifying `cssClass: 'inline-options'` on the radio field config.
 
 <a name="field-balloon"></a>
 ### Balloon Selector
@@ -485,7 +485,7 @@ Radio lists support three ways of defining the options, exactly like the [dropdo
             female: Female
             male: Male
 
-Balloon selectors support three ways of defining the options, exactly like the [dropdown field type](#field-dropdown).
+Balloon selectors support the same methods for defining the options as the [dropdown field type](#field-dropdown).
 
 <a name="field-checkbox"></a>
 ### Checkbox
@@ -514,7 +514,7 @@ Balloon selectors support three ways of defining the options, exactly like the [
             close_account: Close account
             modify_account: Modify account
 
-Checkbox lists support three ways of defining the options, exactly like the [dropdown field type](#field-dropdown) and also support secondary descriptions, found in the [radio field type](#field-radio). Options can be displayed inline with each other instead of in separate rows by specifying `cssClass: 'inline-options'` on the checkboxlist field config.
+Checkbox lists support the same methods for defining the options as the [dropdown field type](#field-dropdown) and also support secondary descriptions, found in the [radio field type](#field-radio). Options can be displayed inline with each other instead of in separate rows by specifying `cssClass: 'inline-options'` on the checkboxlist field config.
 
 <a name="field-switch"></a>
 ### Switch
@@ -1033,7 +1033,7 @@ The available toolbar buttons are:
         type: taglist
         separator: space
 
-A tag list can support three ways of defining the `options`, exactly like the [dropdown field type](#field-dropdown).
+A tag list support the same methods for defining the options as the [dropdown field type](#field-dropdown).
 
     tags:
         type: taglist

--- a/backend-forms.md
+++ b/backend-forms.md
@@ -454,7 +454,7 @@ Supplying the dropdown options to the model class:
         return ['published' => 'Published', ...];
     }
 
-The sixth method uses an array that contains the class as the first argument and the method as the second argument; a static method must be defined in the model class:
+The sixth method allows you to specify a callable object via an array definition. If using PHP, you're able to provide an array with the first element being the object and the second element being the method you want to call on that object. If you're using YAML, you're limited to a static method defined as the second element and the namespaced reference to a class as the first element:
 
     status:
         label: Blog Post Status

--- a/backend-forms.md
+++ b/backend-forms.md
@@ -440,7 +440,7 @@ Supplying the dropdown options to the model class:
         return ['published' => 'Published', ...];
     }
 
-The fifth method uses a static method declared in the model class:
+The fifth method allows you to specify a static method on a class to return the options:
 
     status:
         label: Blog Post Status

--- a/backend-forms.md
+++ b/backend-forms.md
@@ -375,7 +375,22 @@ For more information on model validation, please visit [the documentation page](
 <a name="field-dropdown"></a>
 ### Dropdown
 
-`dropdown` - renders a dropdown with specified options. There are 4 ways to provide the drop-down options. The first method defines `options` directly in the YAML file:
+`dropdown` - renders a dropdown with specified options. There are 6 ways to provide the drop-down options.
+
+The first method defines `options` directly in the YAML file(two variants):
+
+(value only):
+
+    status_type:
+        label: Blog Post Status
+        type: dropdown
+        default: published
+        options:
+            draft
+            published
+            archived
+
+(key / value):
 
     status_type:
         label: Blog Post Status
@@ -386,7 +401,7 @@ For more information on model validation, please visit [the documentation page](
             published: Published
             archived: Archived
 
-The second method defines options with a method declared in the model's class. If the options element is omitted, the framework expects a method with the name `get*FieldName*Options` to be defined in the model. Using the example above, the model should have the `getStatusTypeOptions` method. The first argument of this method is the current value of this field and the second is the current data object for the entire form. This method should return an array of options in the format **key => label**.
+The second method defines options with a method declared in the model class. If the options element is omitted, the framework expects a method with the name `get*FieldName*Options` to be defined in the model. Using the example above, the model should have the `getStatusTypeOptions` method. The first argument of this method is the current value of this field and the second is the current data object for the entire form. This method should return an array of options in the format **key => label**.
 
     status_type:
         label: Blog Post Status
@@ -411,7 +426,7 @@ The third global method `getDropdownOptions` can also be defined in the model, t
         }
     }
 
-The fourth method uses a specific method declared in the model's class. In the next example the `listStatuses` method should be defined in the model class. This method receives all the same arguments as the `getDropdownOptions` method, and should return an array of options in the format **key => label**.
+The fourth method uses a specific method declared in the model class. In the next example the `listStatuses` method should be defined in the model class. This method receives all the same arguments as the `getDropdownOptions` method, and should return an array of options in the format **key => label**.
 
     status:
         label: Blog Post Status
@@ -424,6 +439,36 @@ Supplying the dropdown options to the model class:
     {
         return ['published' => 'Published', ...];
     }
+
+The fifth method uses a static method declared in the model class:
+
+    status:
+        label: Blog Post Status
+        type: dropdown
+        options: FormHelper::staticMethodOptions
+
+Supplying the dropdown options to the model class:
+
+    public static function staticMethodOptions($fieldName, $value, $formData)
+    {
+        return ['published' => 'Published', ...];
+    }
+
+The sixth method uses an array that contains the class as the first argument and the method as the second argument; a static method must be defined in the model class:
+
+    status:
+        label: Blog Post Status
+        type: dropdown
+        options: [FormHelper, staticMethodOptions]
+
+Supplying the dropdown options to the model class:
+
+    public static function staticMethodOptions($fieldName, $value, $formData)
+    {
+        return ['published' => 'Published', ...];
+    }
+
+
 
 To define the behavior when there is no selection, you may specify an `emptyOption` value to include an empty option that can be reselected.
 
@@ -623,7 +668,7 @@ There are two ways to provide the available colors for the colorpicker. The firs
         type: colorpicker
         availableColors: ['#000000', '#111111', '#222222']
 
-The second method uses a specific method declared in the model's class.  This method should return an array of hex colors in the same format as in the example above. The first argument of this method is the field name, the second is the currect value of the field, and the third is the current data object for the entire form.
+The second method uses a specific method declared in the model class.  This method should return an array of hex colors in the same format as in the example above. The first argument of this method is the field name, the second is the currect value of the field, and the third is the current data object for the entire form.
 
     color:
         label: Background


### PR DESCRIPTION
The documentation was not up-to-date regarding the different methods to provide options list for radio, checkboxlist, taglist and balloon-selector field types