### PR TITLE
update required fields for `BackendAuth::register`

### DIFF
--- a/backend-users.md
+++ b/backend-users.md
@@ -33,7 +33,8 @@ Groups (`\Backend\Models\UserGroup`) are an organizational tool for grouping adm
 The global `BackendAuth` facade can be used for managing administrative users, which primarily inherits the `October\Rain\Auth\Manager` class. To register a new administrator user account, use the `BackendAuth::register` method.
 
     $user = BackendAuth::register([
-        'name' => 'Some User',
+        'first_name' => 'Some',
+        'last_name' => 'User',
         'login' => 'someuser',
         'email' => 'some@website.tld',
         'password' => 'changeme',


### PR DESCRIPTION
using `name` to register backend user throws SQL error:

```
In Connection.php line 664:
  SQLSTATE[42S22]: Column not found: 1054 Unknown column 'name' in 'field list' (SQL: insert into `backend_users` (`n
  ame`, `login`, `email`, `password`, `persist_code`, `updated_at`, `created_at`) values ...
```

the table for `backend_users` expects `first_name` & `last_name` - see '2013_10_01_000001_Db_Backend_Users.php'