### PR TITLE
ZipArchive requirement is fixed by splitting the curl command into two

### DIFF
--- a/console-commands.md
+++ b/console-commands.md
@@ -39,11 +39,15 @@ Console installation can be performed using the native system or with [Composer]
 <a name="console-install-quick"></a>
 ### Quick start install
 
-Run this in your terminal to get the latest copy of October:
+Get the latest copy of October:
 
-    curl -s https://octobercms.com/api/installer | php
+    curl -s https://octobercms.com/api/installer --output installer.php
 
-Or if you don't have curl:
+Then run:
+
+    php installer.php
+
+Alternatively if you don't have curl:
 
     php -r "eval('?>'.file_get_contents('https://octobercms.com/api/installer'));"
 
@@ -86,7 +90,7 @@ You also may wish to inspect **config/app.php** and **config/cms.php** to change
 The `october:update` command will request updates from the October gateway. It will update the core application and plugin files, then perform a database migration.
 
     php artisan october:update
-    
+
 > **IMPORTANT**: If you are using [using composer](#console-install-composer) do **NOT** run this command without first making sure that `cms.disableCoreUpdates` is set to true. Doing so will cause conflicts between the marketplace version of October and the version available through composer. In order to update the core October installation when using composer run `composer update` instead.
 
 <a name="console-up-command"></a>
@@ -99,14 +103,14 @@ The `october:up` command will perform a database migration, creating database ta
 The inverse command `october:down` will reverse all migrations, dropping database tables and deleting data. Care should be taken when using this command. The [plugin refresh command](#plugin-refresh-command) is a useful alternative for debugging a single plugin.
 
     php artisan october:down
-    
+
 <a name="change-backend-user-password-command"></a>
 ### Change Backend user password
 
 The `october:passwd` command will allow the password of a Backend user or administrator to be changed via the command-line. This is useful if someone gets locked out of their October CMS install, or for changing the password for the default administrator account.
 
     php artisan october:passwd username password
-    
+
 You may provide the username/email and password as both the first and second argument, or you may leave the arguments blank, in which case the command will be run interactively.
 
 <a name="plugin-commands"></a>


### PR DESCRIPTION
Hello there, 

Even though I made sure to install the extensions required, I couldn't install OctoberCMS this way as described in the docs:

```
$ docker exec -itu 1000:1000 octobercms_php_fpm curl -s https://octobercms.com/api/installer | php
Some settings on your machine make OctoberCMS unable to install properly.
Make sure that you fix the issues listed below and run this script again:

The ZipArchive extension is missing.
Install it to continue
```
However, the following works okay for me:

```
$ docker exec -itu 1000:1000 octobercms_php_fpm php installer.php
All settings correct for installing OctoberCMS
Downloading OctoberCMS...

OctoberCMS successfully installed to: /usr/share/nginx/octobercms
``` 
On the other hand, also I was wondering if it'd make sense to use `\ZipArchive` instead of `ZipArchive` in the install script.
 