### PR TITLE
fix syntax highlight language typo

### DIFF
--- a/backend-forms.md
+++ b/backend-forms.md
@@ -645,7 +645,7 @@ There are various form widgets included as standard, although it is common for p
 
 Option | Description
 ------------- | -------------
-**language** | code language, for example, php, css, js, html. Default: php.
+**language** | code language, for example, php, css, javascript, html. Default: php.
 **showGutter** | shows a gutter with line numbers. Default: true.
 **wrapWords** | breaks long lines on to a new line. Default true.
 **fontSize** | the text font size. Default: 12.


### PR DESCRIPTION
A `language` value of `js` yields a plaintext codeeditor. This should be `javascript` for proper syntax highlighting.