### PR TITLE
Add missing label in partial example + fix model singular

### DIFF
--- a/backend-lists.md
+++ b/backend-lists.md
@@ -373,8 +373,9 @@ To display a column that shows the number of related records, use the `useRelati
 `partial` - renders a partial, the `path` value can refer to a partial view file otherwise the column name is used as the partial name. Inside the partial these variables are available: `$value` is the default cell value, `$record` is the model used for the cell and `$column` is the configured class object `Backend\Classes\ListColumn`.
 
     content:
+        label: Content
         type: partial
-        path: ~/plugins/acme/blog/models/comments/_content_column.htm
+        path: ~/plugins/acme/blog/models/comment/_content_column.htm
 
 <a name="column-colorpicker"></a>
 ### Color Picker


### PR DESCRIPTION
Even if the label field is not mandatory, all the examples in the page provide one.