### PR TITLE
Add storage/app/resized directory to config rules

### DIFF
--- a/setup-deployment.md
+++ b/setup-deployment.md
@@ -116,6 +116,7 @@ Use the following code in **server** section. If you have installed October into
     ## Let nginx return 404 if static file not exists
     location ~ ^/storage/app/uploads/public { try_files $uri 404; }
     location ~ ^/storage/app/media { try_files $uri 404; }
+    location ~ ^/storage/app/resized { try_files $uri 404; }
     location ~ ^/storage/app/resources { try_files $uri 404; }
     location ~ ^/storage/temp/public { try_files $uri 404; }
 
@@ -161,6 +162,7 @@ Paste the following code in the editor and change the **host address** and  **se
             "^/(system|themes/[\w-]+)/assets/([\w-]+/)+[-\w^&'@{}[\],$=!#().%+~/ ]+\.(jpg|jpeg|gif|png|svg|swf|avi|mpg|mpeg|mp3|flv|ico|css|js|woff|ttf)(\?.*|)$" => "$0",
             "^/storage/app/uploads/public/[\w-]+/.*$" => "$0",
             "^/storage/app/media/.*$" => "$0",
+            "^/storage/app/resized/.*$" => "$0",
             "^/storage/app/resources/.*$" => "$0",
             "^/storage/temp/public/[\w-]+/.*$" => "$0",
             "^/(favicon\.ico)$" => "$0",
@@ -185,6 +187,7 @@ If your webserver is running Internet Information Services (IIS) you can use the
                            <add input="{REQUEST_FILENAME}" matchType="IsFile" pattern="^/.well-known/*" negate="true" />
                            <add input="{REQUEST_FILENAME}" matchType="IsFile" pattern="^/storage/app/uploads/public/.*" negate="true" />
                            <add input="{REQUEST_FILENAME}" matchType="IsFile" pattern="^/storage/app/media/.*" negate="true" />
+                           <add input="{REQUEST_FILENAME}" matchType="IsFile" pattern="^/storage/app/resized/.*" negate="true" />
                            <add input="{REQUEST_FILENAME}" matchType="IsFile" pattern="^/storage/app/resources/.*" negate="true" />
                            <add input="{REQUEST_FILENAME}" matchType="IsFile" pattern="^/storage/temp/public/.*" negate="true" />
                            <add input="{REQUEST_FILENAME}" matchType="IsFile" pattern="^/themes/.*/(assets|resources)/.*" negate="true" />


### PR DESCRIPTION
The Resizer adds images to the storage/app/resized directory, but this directory is not in the rules.