### PR TITLE
A better way for Checking a Partial Exists

### DIFF
--- a/2.x/markup/tag-partial.md
+++ b/2.x/markup/tag-partial.md
@@ -62,10 +62,10 @@ The contents are then available as the `body` variable.
 In any template you can check if a partial content exists by using the `partial()` function. This lets you to generate different markup depending on whether the partial exists or not. Example:
 
 ```twig
-{% set cardPartial = 'my-cards/' ~ cardCode %}
+{% set cardPartial = partial('my-cards/' ~ cardCode) %}
 
-{% if partial(cardPartial) %}
-    {% partial cardPartial %}
+{% if cardPartial %}
+    {{ cardPartial|raw }}
 {% else %}
     <p>Card not found!</p>
 {% endif %}


### PR DESCRIPTION
I realize that when using ```parital(cardPartial)``` to checking a Partial Exists. if the partial has some ```{% put ... %}``` and then using {% partial cardPartial %} it will put twice to the placeholder. So to avoid this i suggest using like my PR.

```twig
{% set cardPartial = partial('my-cards/' ~ cardCode) %}

{% if cardPartial %}
    {{ cardPartial|raw }}
{% else %}
    <p>Card not found!</p>
{% endif %}
```
