### PR TITLE
Importing & Exporting - Integration with List Behavior - toolbar button

### DIFF
--- a/2.x/backend/import-export.md
+++ b/2.x/backend/import-export.md
@@ -291,6 +291,16 @@ export:
     useList: true
 ```
 
+Then add link to _list_toolbar.htm:
+
+```php
+<a
+  href="<?= Backend::url('acme/campaign/subscribers/export') ?>"
+  class="btn btn-default oc-icon-download">
+  Export records
+ </a>
+```
+
 If you are using [multiple list definitions](lists.md#oc-multiple-list-definitions), then you can supply the list definition:
 
 ```yaml


### PR DESCRIPTION
I´m adding missing information how to add toolbar button if I choose useList: true in export config. There is sentence: "Here is the only configuration needed", but it is not true, it won´t add export button automatically.