### PR TITLE
Add a link to plugin activation page from plugin creation page

### DIFF
--- a/3.x/extend/system/plugins.md
+++ b/3.x/extend/system/plugins.md
@@ -243,6 +243,9 @@ class SomeUpgradeFile extends Migration
 }
 ```
 
+### Activate your plugin
+Now that your plugin is created, you need to activate it in order to use it in your project. See [Installing packages](../resources/installing-packages.md#enable-plugin).
+
 #### See Also
 
 ::: also


### PR DESCRIPTION
When a plugin is created, it is required to be activated manually. I struggled a moment to find out. A link in the doc between those two section could be a benefit.