### PR TITLE
Fix broken links in CMS components doc

### DIFF
--- a/3.x/cms/components/collection.md
+++ b/3.x/cms/components/collection.md
@@ -11,7 +11,7 @@ The following properties are supported by the component.
 
 Property | Description
 -------- | -------------
-**handle** | The handle of the [entry blueprint](./blueprints.md).
+**handle** | The handle of the [entry blueprint](../tailor/blueprints.md).
 **recordsPerPage** | Number of records to display on a single page. Leave empty to disable pagination.
 **pageNumber** | This value is used to determine what page the user is on.
 **sortColumn** | Column name the records should be ordered by.

--- a/3.x/cms/components/global.md
+++ b/3.x/cms/components/global.md
@@ -11,7 +11,7 @@ The following properties are supported by the component.
 
 Property | Description
 -------- | -------------
-**handle** | The handle of the [global blueprint](./blueprints.md).
+**handle** | The handle of the [global blueprint](../tailor/blueprints.md).
 
 ## Basic Usage
 

--- a/3.x/cms/components/section.md
+++ b/3.x/cms/components/section.md
@@ -11,7 +11,7 @@ The following properties are supported by the component.
 
 Property | Description
 -------- | -------------
-**handle** | The handle of the [entry blueprint](./blueprints.md).
+**handle** | The handle of the [entry blueprint](../tailor/blueprints.md).
 **identifier** | Use this identifier key to look up the entry, supported values are `slug`, `fullslug` or `id`. Default: `slug`
 **value** | Use this identifier value to use to look up the entry, optional. Leave empty to use the identifier key as the URL parameter name. Can be set to a hard coded value, or a custom parameter, eg: `{{ :slug }}`
 **isDefault** | Make this the default page when previewing the entry. Default: `true`.


### PR DESCRIPTION
Fix broken links in CMS components doc, under Component Globals, Section and Collection whereby the link to Blueprint should have point back to Tailor documentation.