### PR TITLE
Docs/form relation refresh from ajax handler

### DIFF
--- a/3.x/extend/forms/form-controller.md
+++ b/3.x/extend/forms/form-controller.md
@@ -575,6 +575,40 @@ public function onMyAction()
 
 > **Note:** If your relation fields are declared directly inside `config_form.yaml` as `type: relation`, they are part of the form widget and will be refreshed by `formGetWidget()->onRefresh()` automatically. Use `relationRefresh()` only for relations managed by `RelationController` (declared in `config_relation.yaml`).
 
+### Getting the Active Form Model
+
+The `formGetModel` method returns the model currently bound to the form. This is especially useful in custom AJAX handlers where the form is open in a popup and the model is already initialised by the behavior — avoiding the need to re-query the database using `post('record_id')`.
+
+```php
+public function onMyAction()
+{
+    $model = $this->formGetModel();
+
+    $model->status = 'processed';
+    $model->save();
+
+    return $this->formGetWidget()->onRefresh();
+}
+```
+
+### Extending Every Form Refresh
+
+The `formExtendRefreshResults` override is called automatically on every `onRefresh` cycle, including calls triggered by field dependencies or `formGetWidget()->onRefresh()`. Use it to inject additional DOM updates into any refresh without modifying individual AJAX handlers.
+
+```php
+public function formExtendRefreshResults($host, $result)
+{
+    $model = $this->formGetModel();
+
+    // Appended to every refresh response automatically
+    return $result + [
+        '#my-status-block' => $this->makePartial('status_block', ['model' => $model]),
+    ];
+}
+```
+
+This is the inverse of `formGetWidget()->onRefresh()`: instead of triggering a full refresh manually, you declare what should always be appended whenever a refresh occurs.
+
 ## Validating Form Fields
 
 To validate the fields of your form you can make use of the [Validation trait](../database/traits.md) in your model.

--- a/3.x/extend/forms/form-controller.md
+++ b/3.x/extend/forms/form-controller.md
@@ -544,6 +544,37 @@ User::extend(function ($model) {
 });
 ```
 
+### Refreshing the Form via AJAX
+
+When a custom AJAX handler needs to update all form fields at once, use the form widget's `onRefresh` method. This re-renders the entire form and returns the result as a DOM update array, which the AJAX framework applies automatically.
+
+```php
+public function onMyAction()
+{
+    // ... your logic ...
+
+    // Re-renders all form fields, tabs and custom partials in one request
+    return $this->formGetWidget()->onRefresh();
+}
+```
+
+To refresh the form and one or more relation containers simultaneously, merge the results:
+
+```php
+public function onMyAction()
+{
+    // ... your logic ...
+
+    return array_merge(
+        $this->formGetWidget()->onRefresh(),  // all form fields
+        $this->relationRefresh('files'),       // a specific relation
+        $this->relationRefresh('comments')     // another relation
+    );
+}
+```
+
+> **Note:** If your relation fields are declared directly inside `config_form.yaml` as `type: relation`, they are part of the form widget and will be refreshed by `formGetWidget()->onRefresh()` automatically. Use `relationRefresh()` only for relations managed by `RelationController` (declared in `config_relation.yaml`).
+
 ## Validating Form Fields
 
 To validate the fields of your form you can make use of the [Validation trait](../database/traits.md) in your model.

--- a/3.x/extend/forms/relation-controller.md
+++ b/3.x/extend/forms/relation-controller.md
@@ -478,6 +478,48 @@ public function relationExtendRefreshResults($field)
 }
 ```
 
+### Refreshing Relations via AJAX
+
+The `relationRefresh` method is available in your controller to programmatically refresh a relation container from a custom AJAX handler. It returns a DOM update array that the AJAX framework applies automatically.
+
+```php
+public function onSaveSignature()
+{
+    // ... your logic ...
+
+    // Refreshes the view and toolbar of the 'files' relation
+    return $this->relationRefresh('files');
+}
+```
+
+To refresh multiple relations at once, merge the results into a single array:
+
+```php
+public function onSaveSignature()
+{
+    // ... your logic ...
+
+    return array_merge(
+        $this->relationRefresh('files'),
+        $this->relationRefresh('comments')
+    );
+}
+```
+
+To refresh both the entire form and one or more relations simultaneously, combine with `formGetWidget()->onRefresh()` from the [Form Controller](./form-controller.md):
+
+```php
+public function onSaveSignature()
+{
+    // ... your logic ...
+
+    return array_merge(
+        $this->formGetWidget()->onRefresh(),  // all form fields
+        $this->relationRefresh('files')        // relation container
+    );
+}
+```
+
 #### See Also
 
 ::: also

--- a/4.x/extend/forms/form-controller.md
+++ b/4.x/extend/forms/form-controller.md
@@ -627,6 +627,40 @@ public function onMyAction()
 
 > **Note:** If your relation fields are declared directly inside `config_form.yaml` as `type: relation`, they are part of the form widget and will be refreshed by `formGetWidget()->onRefresh()` automatically. Use `relationRefresh()` only for relations managed by `RelationController` (declared in `config_relation.yaml`).
 
+### Getting the Active Form Model
+
+The `formGetModel` method returns the model currently bound to the form. This is especially useful in custom AJAX handlers where the form is open in a popup and the model is already initialised by the behavior — avoiding the need to re-query the database using `post('record_id')`.
+
+```php
+public function onMyAction()
+{
+    $model = $this->formGetModel();
+
+    $model->status = 'processed';
+    $model->save();
+
+    return $this->formGetWidget()->onRefresh();
+}
+```
+
+### Extending Every Form Refresh
+
+The `formExtendRefreshResults` override is called automatically on every `onRefresh` cycle, including calls triggered by field dependencies or `formGetWidget()->onRefresh()`. Use it to inject additional DOM updates into any refresh without modifying individual AJAX handlers.
+
+```php
+public function formExtendRefreshResults($host, $result)
+{
+    $model = $this->formGetModel();
+
+    // Appended to every refresh response automatically
+    return $result + [
+        '#my-status-block' => $this->makePartial('status_block', ['model' => $model]),
+    ];
+}
+```
+
+This is the inverse of `formGetWidget()->onRefresh()`: instead of triggering a full refresh manually, you declare what should always be appended whenever a refresh occurs.
+
 ## Validating Form Fields
 
 To validate the fields of your form you can make use of the [Validation trait](../database/traits.md) in your model.

--- a/4.x/extend/forms/form-controller.md
+++ b/4.x/extend/forms/form-controller.md
@@ -596,6 +596,37 @@ User::extend(function ($model) {
 });
 ```
 
+### Refreshing the Form via AJAX
+
+When a custom AJAX handler needs to update all form fields at once, use the form widget's `onRefresh` method. This re-renders the entire form and returns the result as a DOM update array, which the AJAX framework applies automatically.
+
+```php
+public function onMyAction()
+{
+    // ... your logic ...
+
+    // Re-renders all form fields, tabs and custom partials in one request
+    return $this->formGetWidget()->onRefresh();
+}
+```
+
+To refresh the form and one or more relation containers simultaneously, merge the results:
+
+```php
+public function onMyAction()
+{
+    // ... your logic ...
+
+    return array_merge(
+        $this->formGetWidget()->onRefresh(),  // all form fields
+        $this->relationRefresh('files'),       // a specific relation
+        $this->relationRefresh('comments')     // another relation
+    );
+}
+```
+
+> **Note:** If your relation fields are declared directly inside `config_form.yaml` as `type: relation`, they are part of the form widget and will be refreshed by `formGetWidget()->onRefresh()` automatically. Use `relationRefresh()` only for relations managed by `RelationController` (declared in `config_relation.yaml`).
+
 ## Validating Form Fields
 
 To validate the fields of your form you can make use of the [Validation trait](../database/traits.md) in your model.

--- a/4.x/extend/forms/relation-controller.md
+++ b/4.x/extend/forms/relation-controller.md
@@ -478,6 +478,48 @@ public function relationExtendRefreshResults($field)
 }
 ```
 
+### Refreshing Relations via AJAX
+
+The `relationRefresh` method is available in your controller to programmatically refresh a relation container from a custom AJAX handler. It returns a DOM update array that the AJAX framework applies automatically.
+
+```php
+public function onSaveSignature()
+{
+    // ... your logic ...
+
+    // Refreshes the view and toolbar of the 'files' relation
+    return $this->relationRefresh('files');
+}
+```
+
+To refresh multiple relations at once, merge the results into a single array:
+
+```php
+public function onSaveSignature()
+{
+    // ... your logic ...
+
+    return array_merge(
+        $this->relationRefresh('files'),
+        $this->relationRefresh('comments')
+    );
+}
+```
+
+To refresh both the entire form and one or more relations simultaneously, combine with `formGetWidget()->onRefresh()` from the [Form Controller](./form-controller.md):
+
+```php
+public function onSaveSignature()
+{
+    // ... your logic ...
+
+    return array_merge(
+        $this->formGetWidget()->onRefresh(),  // all form fields
+        $this->relationRefresh('files')        // relation container
+    );
+}
+```
+
 #### See Also
 
 ::: also


### PR DESCRIPTION
## Summary

This PR documents several undocumented but publicly available backend APIs
for working with forms in AJAX and popup contexts. All methods exist as
`public` functions in the source but were entirely absent from the docs.

## Problem

Developers writing custom AJAX handlers in backend controllers have no
documented way to:
- Refresh the entire form without hardcoded DOM selectors
- Refresh multiple relation containers at once
- Access the form's bound model inside an AJAX handler
- Automatically append extra DOM updates to every form refresh

The only approaches mentioned in current docs are `Redirect::refresh()`
(full page reload) or manually constructing brittle `['#selector' => $html]`
arrays. This PR fills that gap.

## Changes

### `form-controller.md` (3.x, 4.x) — 3 new sections under *Extending Form Behavior*:

**Refreshing the Form via AJAX**
- `$this->formGetWidget()->onRefresh()` — re-renders the entire form in one AJAX response
- `array_merge()` pattern to combine form refresh with `relationRefresh()`

**Getting the Active Form Model**
- `$this->formGetModel()` — returns the model already bound to the form widget,
  avoids re-querying via `Order::find(post('record_id'))` in popup context

**Extending Every Form Refresh**
- `formExtendRefreshResults($host, $result)` — override called on every refresh
  cycle; lets you inject DOM updates into any refresh without touching individual
  AJAX handlers. The inverse of calling `onRefresh()` manually.

### `relation-controller.md` (3.x, 4.x) — 1 new section *Refreshing Relations via AJAX*:

- `$this->relationRefresh('fieldName')` — refresh a single relation container
- `array_merge()` for multiple relations at once
- Combined usage with `formGetWidget()->onRefresh()`

## Source references

| Method | Source |
|---|---|
| `Form::onRefresh()` | `modules/backend/widgets/Form.php:460` |
| `RelationController::relationRefresh()` | `modules/backend/behaviors/RelationController.php:558` |
| `FormController::formGetModel()` | `modules/backend/behaviors/FormController.php:592` |
| `FormController::formExtendRefreshResults()` | `modules/backend/behaviors/FormController.php:184` (hook) |

All methods are `public` and designed for extension, but were never documented.